### PR TITLE
Fix squashed logo and increase height in header/footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 
@@ -193,7 +193,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 
@@ -129,7 +129,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/css/style.css
+++ b/css/style.css
@@ -812,6 +812,10 @@ video {
   width: 1.5rem;
 }
 
+.w-auto {
+  width: auto;
+}
+
 .w-full {
   width: 100%;
 }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 
@@ -189,7 +189,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/portfolio.html
+++ b/portfolio.html
@@ -16,7 +16,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 
@@ -139,7 +139,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/service.html
+++ b/service.html
@@ -16,7 +16,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 
@@ -164,7 +164,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -3,7 +3,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-12 text-center md:text-left">
       <div>
         <div class="mb-6 flex justify-center md:justify-start">
-          <img src="images/logo.png" alt="Lunatech Logo" class="h-12" width="235" height="57">
+          <img src="images/logo.png" alt="Lunatech Logo" class="h-16 w-auto" width="235" height="57">
         </div>
         <h3 class="text-xl font-bold mb-4 italic tracking-widest uppercase">Design. CODE. AI.</h3>
         <p class="text-gray-400 text-sm">Empowering the digital landscape through intelligent innovation.</p>

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -2,7 +2,7 @@
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <div class="flex items-center">
       <a href="index.html" class="flex items-center">
-        <img src="images/logo.png" alt="Lunatech Logo" class="h-10" width="235" height="57">
+        <img src="images/logo.png" alt="Lunatech Logo" class="h-12 w-auto" width="235" height="57">
       </a>
     </div>
 


### PR DESCRIPTION
The logo was vertically squashed because the CSS height class was overriding the intrinsic height, but the browser was still using the explicit `width` attribute from the `<img>` tag. I've increased the heights as requested and added `w-auto` to ensure the aspect ratio is maintained. I also rebuilt the site so that the changes from the template files are reflected in all the root HTML files.

---
*PR created automatically by Jules for task [8818080070087311570](https://jules.google.com/task/8818080070087311570) started by @rynomster*