### PR TITLE
🛡️ Sentinel: [security improvement] Harden Content Security Policy and remove inline styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>About Us | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Contact Us | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -99,7 +99,7 @@
 
                     <!-- Map -->
                     <div class="rounded-2xl overflow-hidden border border-gray-100 shadow-xl h-80">
-                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3303.1119565578763!2d24.9213!3d-34.0535!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1e660e6e8790176d%3A0xc4e5904d0392f694!2sJ-Bay%20Surf%20Village!5e0!3m2!1sen!2sza!4v1651234567890!5m2!1sen!2sza" width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy" title="Google Maps Location" sandbox="allow-scripts allow-same-origin allow-popups" referrerpolicy="no-referrer-when-downgrade">
+                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3303.1119565578763!2d24.9213!3d-34.0535!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1e660e6e8790176d%3A0xc4e5904d0392f694!2sJ-Bay%20Surf%20Village!5e0!3m2!1sen!2sza!4v1651234567890!5m2!1sen!2sza" width="100%" height="100%" class="border-0" allowfullscreen="" loading="lazy" title="Google Maps Location" sandbox="allow-scripts allow-same-origin allow-popups" referrerpolicy="no-referrer-when-downgrade">
                         </iframe>
                     </div>
                 </div>

--- a/css/style.css
+++ b/css/style.css
@@ -630,6 +630,14 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
+.nav-link-active {
+  border-bottom-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(255 255 255 / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
 .fixed {
   position: fixed;
 }
@@ -990,6 +998,10 @@ video {
 
 .border {
   border-width: 1px;
+}
+
+.border-0 {
+  border-width: 0px;
 }
 
 .border-2 {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="scroll-smooth">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Lunatech (Pty) Ltd. | Design. CODE. AI.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/portfolio.html
+++ b/portfolio.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Portfolio | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/service.html
+++ b/service.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Our Services | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>About Us | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Contact Us | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -66,7 +66,7 @@
                     <div class="rounded-2xl overflow-hidden border border-gray-100 shadow-xl h-80">
                         <iframe
                             src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3303.1119565578763!2d24.9213!3d-34.0535!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1e660e6e8790176d%3A0xc4e5904d0392f694!2sJ-Bay%20Surf%20Village!5e0!3m2!1sen!2sza!4v1651234567890!5m2!1sen!2sza"
-                            width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy"
+                            width="100%" height="100%" class="border-0" allowfullscreen="" loading="lazy"
                             title="Google Maps Location"
                             sandbox="allow-scripts allow-same-origin allow-popups"
                             referrerpolicy="no-referrer-when-downgrade">

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="scroll-smooth">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Lunatech (Pty) Ltd. | Design. CODE. AI.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/pages/portfolio.html
+++ b/src/pages/portfolio.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Portfolio | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/pages/service.html
+++ b/src/pages/service.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta name="referrer" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.google.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <title>Our Services | Lunatech (Pty) Ltd.</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This PR enhances the security of the Lunatech 2026 website by hardening the Content Security Policy (CSP) and eliminating inline styles that were previously required for the CSP to function.

### 🛡️ Sentinel Security Improvement

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Potential for XSS and CSS injection due to `'unsafe-inline'` in CSP; risk of plugin-based attacks (Flash, etc.) due to missing `object-src` directive.
🎯 **Impact**: An attacker could potentially inject malicious styles or scripts if another vulnerability existed. Removing `data:` from `img-src` also prevents some categories of XSS that use data URIs.
🔧 **Fix**: 
- Removed `'unsafe-inline'` from `style-src` in all pages.
- Removed `data:` from `img-src` in all pages.
- Added `object-src 'none'` to all pages.
- Migrated the remaining inline style in `src/pages/contact.html` (Google Maps iframe) to a Tailwind CSS utility class (`border-0`).
✅ **Verification**: 
- Ran `pnpm build` to regenerate all HTML files.
- Verified via Playwright that the CSP meta tags are updated and that the Google Maps iframe correctly uses the Tailwind class.
- Confirmed that the active navigation link highlighting (which uses `classList.add` in `js/navigation.js`) is NOT affected by the CSP change as it doesn't use inline styles.

---
*PR created automatically by Jules for task [6041383237351887205](https://jules.google.com/task/6041383237351887205) started by @rynomster*